### PR TITLE
Add RebuildBatched

### DIFF
--- a/nested_set_test.go
+++ b/nested_set_test.go
@@ -344,6 +344,164 @@ func TestRebuild(t *testing.T) {
 	assertNodeEqual(t, lilysDresses, 4, 5, 1, 0, lilysClothing.ID)
 }
 
+func TestRebuildBatched(t *testing.T) {
+	const batchSize = 5
+	initData()
+	affectedCount, err := RebuildBatched(db, clothing, true, batchSize)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, affectedCount)
+	reloadCategories()
+
+	assertNodeEqual(t, clothing, 1, 22, 0, 2, 0)
+	assertNodeEqual(t, mens, 2, 9, 1, 1, clothing.ID)
+	assertNodeEqual(t, suits, 3, 8, 2, 2, mens.ID)
+	assertNodeEqual(t, slacks, 4, 5, 3, 0, suits.ID)
+	assertNodeEqual(t, jackets, 6, 7, 3, 0, suits.ID)
+	assertNodeEqual(t, womens, 10, 21, 1, 3, clothing.ID)
+	assertNodeEqual(t, dresses, 11, 16, 2, 2, womens.ID)
+	assertNodeEqual(t, eveningGowns, 12, 13, 3, 0, dresses.ID)
+	assertNodeEqual(t, sunDresses, 14, 15, 3, 0, dresses.ID)
+	assertNodeEqual(t, skirts, 17, 18, 2, 0, womens.ID)
+	assertNodeEqual(t, blouses, 19, 20, 2, 0, womens.ID)
+
+	sunDresses.Rgt = 123
+	sunDresses.Lft = 12
+	sunDresses.Depth = 1
+	sunDresses.ChildrenCount = 100
+	err = db.Updates(&sunDresses).Error
+	assert.NoError(t, err)
+	reloadCategories()
+	assertNodeEqual(t, sunDresses, 12, 123, 1, 100, dresses.ID)
+
+	affectedCount, err = RebuildBatched(db, clothing, true, batchSize)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, affectedCount)
+	reloadCategories()
+
+	assertNodeEqual(t, clothing, 1, 22, 0, 2, 0)
+	assertNodeEqual(t, mens, 2, 9, 1, 1, clothing.ID)
+	assertNodeEqual(t, suits, 3, 8, 2, 2, mens.ID)
+	assertNodeEqual(t, slacks, 4, 5, 3, 0, suits.ID)
+	assertNodeEqual(t, jackets, 6, 7, 3, 0, suits.ID)
+	assertNodeEqual(t, womens, 10, 21, 1, 3, clothing.ID)
+	assertNodeEqual(t, dresses, 11, 16, 2, 2, womens.ID)
+	assertNodeEqual(t, eveningGowns, 14, 15, 3, 0, dresses.ID)
+	assertNodeEqual(t, sunDresses, 12, 13, 3, 0, dresses.ID)
+	assertNodeEqual(t, skirts, 17, 18, 2, 0, womens.ID)
+	assertNodeEqual(t, blouses, 19, 20, 2, 0, womens.ID)
+
+	affectedCount, err = RebuildBatched(db, clothing, true, batchSize)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, affectedCount)
+	reloadCategories()
+
+	assertNodeEqual(t, clothing, 1, 22, 0, 2, 0)
+	assertNodeEqual(t, mens, 2, 9, 1, 1, clothing.ID)
+	assertNodeEqual(t, suits, 3, 8, 2, 2, mens.ID)
+	assertNodeEqual(t, slacks, 4, 5, 3, 0, suits.ID)
+	assertNodeEqual(t, jackets, 6, 7, 3, 0, suits.ID)
+	assertNodeEqual(t, womens, 10, 21, 1, 3, clothing.ID)
+	assertNodeEqual(t, dresses, 11, 16, 2, 2, womens.ID)
+	assertNodeEqual(t, eveningGowns, 14, 15, 3, 0, dresses.ID)
+	assertNodeEqual(t, sunDresses, 12, 13, 3, 0, dresses.ID)
+	assertNodeEqual(t, skirts, 17, 18, 2, 0, womens.ID)
+	assertNodeEqual(t, blouses, 19, 20, 2, 0, womens.ID)
+
+	hat := *CategoryFactory.MustCreateWithOption(map[string]interface{}{
+		"Title":    "Hat",
+		"ParentID": sql.NullInt64{Valid: false},
+	}).(*Category)
+
+	affectedCount, err = RebuildBatched(db, clothing, false, batchSize)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, affectedCount)
+
+	affectedCount, err = RebuildBatched(db, clothing, true, batchSize)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, affectedCount)
+	reloadCategories()
+	hat, _ = findNode(db, hat.ID)
+
+	assertNodeEqual(t, clothing, 1, 22, 0, 2, 0)
+	assertNodeEqual(t, mens, 2, 9, 1, 1, clothing.ID)
+	assertNodeEqual(t, suits, 3, 8, 2, 2, mens.ID)
+	assertNodeEqual(t, slacks, 4, 5, 3, 0, suits.ID)
+	assertNodeEqual(t, jackets, 6, 7, 3, 0, suits.ID)
+	assertNodeEqual(t, womens, 10, 21, 1, 3, clothing.ID)
+	assertNodeEqual(t, dresses, 11, 16, 2, 2, womens.ID)
+	assertNodeEqual(t, eveningGowns, 14, 15, 3, 0, dresses.ID)
+	assertNodeEqual(t, sunDresses, 12, 13, 3, 0, dresses.ID)
+	assertNodeEqual(t, skirts, 17, 18, 2, 0, womens.ID)
+	assertNodeEqual(t, blouses, 19, 20, 2, 0, womens.ID)
+	assertNodeEqual(t, hat, 23, 24, 0, 0, 0)
+
+	jacksClothing := *CategoryFactory.MustCreateWithOption(map[string]interface{}{
+		"Title":    "Jack's Clothing",
+		"ParentID": sql.NullInt64{Valid: false},
+		"UserType": "User",
+		"UserID":   8686,
+	}).(*Category)
+	jacksSuits := *CategoryFactory.MustCreateWithOption(map[string]interface{}{
+		"Title":    "Jack's Suits",
+		"ParentID": sql.NullInt64{Valid: true, Int64: jacksClothing.ID},
+		"UserType": "User",
+		"UserID":   8686,
+	}).(*Category)
+	jacksHat := *CategoryFactory.MustCreateWithOption(map[string]interface{}{
+		"Title":    "Jack's Hat",
+		"UserType": "User",
+		"UserID":   8686,
+		"ParentID": sql.NullInt64{Valid: false},
+	}).(*Category)
+	jacksSlacks := *CategoryFactory.MustCreateWithOption(map[string]interface{}{
+		"Title":    "Jack's Slacks",
+		"ParentID": sql.NullInt64{Valid: true, Int64: jacksClothing.ID},
+		"UserType": "User",
+		"UserID":   8686,
+	}).(*Category)
+
+	lilysHat := *CategoryFactory.MustCreateWithOption(map[string]interface{}{
+		"Title":    "Lily's Hat",
+		"UserType": "User",
+		"UserID":   6666,
+		"ParentID": sql.NullInt64{Valid: false},
+	}).(*Category)
+	lilysClothing := *CategoryFactory.MustCreateWithOption(map[string]interface{}{
+		"Title":    "Lily's Clothing",
+		"ParentID": sql.NullInt64{Valid: false},
+		"UserType": "User",
+		"UserID":   6666,
+	}).(*Category)
+	lilysDresses := *CategoryFactory.MustCreateWithOption(map[string]interface{}{
+		"Title":    "Lily's Dresses",
+		"ParentID": sql.NullInt64{Valid: true, Int64: lilysClothing.ID},
+		"UserType": "User",
+		"UserID":   6666,
+	}).(*Category)
+
+	affectedCount, err = RebuildBatched(db, jacksSuits, true, batchSize)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, affectedCount)
+	affectedCount, err = RebuildBatched(db, lilysHat, true, batchSize)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, affectedCount)
+	jacksClothing, _ = findNode(db, jacksClothing.ID)
+	jacksSuits, _ = findNode(db, jacksSuits.ID)
+	jacksSlacks, _ = findNode(db, jacksSlacks.ID)
+	jacksHat, _ = findNode(db, jacksHat.ID)
+	lilysHat, _ = findNode(db, lilysHat.ID)
+	lilysClothing, _ = findNode(db, lilysClothing.ID)
+	lilysDresses, _ = findNode(db, lilysDresses.ID)
+
+	assertNodeEqual(t, jacksClothing, 1, 6, 0, 2, 0)
+	assertNodeEqual(t, jacksSuits, 2, 3, 1, 0, jacksClothing.ID)
+	assertNodeEqual(t, jacksSlacks, 4, 5, 1, 0, jacksClothing.ID)
+	assertNodeEqual(t, jacksHat, 7, 8, 0, 0, 0)
+	assertNodeEqual(t, lilysHat, 1, 2, 0, 0, 0)
+	assertNodeEqual(t, lilysClothing, 3, 6, 0, 1, 0)
+	assertNodeEqual(t, lilysDresses, 4, 5, 1, 0, lilysClothing.ID)
+}
+
 func TestMoveToLeft(t *testing.T) {
 	// case 1
 	initData()


### PR DESCRIPTION
Original `Rebuild` was making thousands of individual update queries. I added `RebuildBatched` which can be 
 called as:
```go
nestedset.RebuildBatched(db.WithContext(ctx), root, true, 1000)
```

The method is postgres specific. And can be used by adding following to `go.mod` file:
```go.mod
replace github.com/longbridgeapp/nested-set => github.com/OrkhanAlikhanov/nested-set v1.5.2
```

If the model has required fields, it will fail with `ERROR: null value in column \"my_column" of relation \"my_table\" violates not-null constraint (SQLSTATE 23502)`. The workaround is to set default values or make columns nullable which is not great but may worth the change.